### PR TITLE
Made doors object local to file

### DIFF
--- a/decor_api/door.lua
+++ b/decor_api/door.lua
@@ -1,6 +1,6 @@
 multidecor.doors = {}
 
-doors = multidecor.doors
+local doors = multidecor.doors
 
 -- Returns new position rotated around 'rotate_p' and rotation correponding to "dir"
 function doors.rotate(pos, dir, rotate_p)


### PR DESCRIPTION
Made the `doors` object local to the file, to avoid overriding the `default:doors` mod's object by the same name, which would cause crashes with placing/opening/closing all doors.