### PR TITLE
Fix crash on using spatula

### DIFF
--- a/modern/covering.lua
+++ b/modern/covering.lua
@@ -231,7 +231,7 @@ minetest.register_tool(":multidecor:spatula", {
 			return
 		end
 
-		next_itemstack = on_place_cover(pointed_thing, next_itemstack, "plaster")
+		next_itemstack = on_place_cover(pointed_thing, next_itemstack, "plaster", placer)
 		inv:set_stack("main", spatula_index+1, next_itemstack)
 	end
 })


### PR DESCRIPTION
In the current `main` branch version, right-clicking with the spatula to place plaster will crash the game:
```
AsyncErr: Lua: Runtime error from mod 'modern' in callback item_OnPlace(): ~/.minetest/mods/multidecor/modern/covering.lua:89: attempt to index local 'placer' (a nil value)
stack traceback:
	~/.minetest/.minetest/mods/multidecor/modern/covering.lua:89: in function 'on_place_cover'
	~/.minetest/mods/multidecor/modern/covering.lua:234: in function <.~/.minetest/mods/multidecor/modern/covering.lua:224>
```

 This adds a missing argument to make sure it doesn't crash.