### PR TITLE
Fix: don't consume furniture item in creative mode

### DIFF
--- a/decor_api/register.lua
+++ b/decor_api/register.lua
@@ -78,12 +78,16 @@ end
 
 function multidecor.register.after_place_node(pos, placer, itemstack)
 	local place = multidecor.placement.check_for_placement(pos, itemstack:get_name())
+	local name = placer and placer:get_player_name() or ""
 
 	if not place then
 		minetest.chat_send_player(placer:get_player_name(), "Not enough free place for the given node!")
 		minetest.remove_node(pos)
 	else
-		itemstack:set_count(itemstack:get_count()-1)
+		if not minetest.is_creative_enabled(name)
+		then
+			itemstack:set_count(itemstack:get_count()-1)
+		end
 	end
 
 	return itemstack


### PR DESCRIPTION
Bug: Furniture items are consumed in creative mode when placed.
Cause: after_place_node decrements itemstack unconditionally.
Fix: Skip consumption in creative mode;